### PR TITLE
Improve searching for items

### DIFF
--- a/src/main/java/Duke/task/TaskList.java
+++ b/src/main/java/Duke/task/TaskList.java
@@ -94,7 +94,7 @@ public class TaskList {
 
         for (int i = 0; i < records.size(); i++) {
             Task current = records.get(i);
-            if (current.description.matches(keyword)) {
+            if (current.description.contains(keyword)) {
                 result.add(current);
             }
         }


### PR DESCRIPTION
Find command returns tasks only if description matches keyword exactly.
This is not flexible and not user-friendy.

Lets add flexibility in searching for items e.g., find items even if
the keyword matches the item only partially.